### PR TITLE
Use get_the_excerpt instead of get_the_content

### DIFF
--- a/includes/widget-recent-posts-extended.php
+++ b/includes/widget-recent-posts-extended.php
@@ -456,7 +456,7 @@ class Recent_Posts_Widget_Extended extends WP_Widget {
  * @link     http://codex.wordpress.org/Function_Reference/wp_trim_words
  */
 function rpwe_excerpt( $length ) {
-	$content = get_the_content();
+	$content = get_the_excerpt();
 	$excerpt = wp_trim_words( $content, $length );
 
 	return $excerpt;


### PR DESCRIPTION
This fixes the same problem identified by https://github.com/satrya/recent-posts-widget-extended/pull/20 but is a better solution, I believe.
