### PR TITLE
Quick fix for "cssID" attribute in shortcodes

### DIFF
--- a/includes/shortcode.php
+++ b/includes/shortcode.php
@@ -15,6 +15,10 @@
  * @since  0.9.4
  */
 function rpwe_shortcode( $atts, $content ) {
+	if (isset($atts['cssid'])) {
+		$atts['cssID'] = $atts['cssid'];
+		unset($atts['cssid']);
+	}
 	$args = shortcode_atts( rpwe_get_default_args(), $atts );
 	return rpwe_get_recent_posts( $args );
 }


### PR DESCRIPTION
"cssID" attribute in shortcode wasn't working.
From codex for "add_shortcode" function: "Shortcode attribute names are always converted to lowercase before they are passed into the handler function. Values are untouched."
Therefore "rpwe_shortcode" function that is used in shortcode.php gets $atts array with lowercased attribute names. And "rpwe_get_default_args" function returns array with key named 'cssID'. Due to the fact that key names are case sensitive, cssID remains empty.
