### PR TITLE
Date filter by Future/Past dates and adjustment of 'now' date.

### DIFF
--- a/classes/widget.php
+++ b/classes/widget.php
@@ -105,6 +105,8 @@ class Recent_Posts_Widget_Extended extends WP_Widget {
 		$instance['offset']           = intval( $new_instance['offset'] );
 		$instance['order']            = stripslashes( $new_instance['order'] );
 		$instance['orderby']          = stripslashes( $new_instance['orderby'] );
+		$instance['date_filter']      = stripslashes( $new_instance['date_filter'] );
+		$instance['date_filter_adj']  = intval( $new_instance['date_filter_adj'] );
 		$instance['post_type']        = $types;
 		$instance['post_status']      = stripslashes( $new_instance['post_status'] );
 		$instance['cat']              = $new_instance['cat'];

--- a/includes/form.php
+++ b/includes/form.php
@@ -125,6 +125,27 @@
 		</select>
 	</p>
 
+	<p>
+		<label for="<?php echo $this->get_field_id( 'date_filter' ); ?>">
+			<?php _e( 'Date Filter', 'recent-posts-widget-extended' ); ?>
+		</label>
+		<select class="widefat" id="<?php echo $this->get_field_id( 'date_filter' ); ?>" name="<?php echo $this->get_field_name( 'date_filter' ); ?>" style="width:100%;">
+			<option value="all" <?php selected( $instance['date_filter'], 'all' ); ?>><?php _e( 'All Dates', 'rpwe' ) ?></option>
+			<option value="after" <?php selected( $instance['date_filter'], 'after' ); ?>><?php _e( 'Future Dates', 'rpwe' ) ?></option>
+			<option value="before" <?php selected( $instance['date_filter'], 'before' ); ?>><?php _e( 'Past Dates', 'rpwe' ) ?></option>
+		</select>
+	</p>
+
+	<p>
+		<label for="<?php echo $this->get_field_id( 'date_filter_adj' ); ?>">
+			<?php _e( 'Date Filter Adjustment', 'recent-posts-widget-extended' ); ?>
+		</label>
+		<input class="widefat" id="<?php echo $this->get_field_id( 'date_filter_adj' ); ?>" name="<?php echo $this->get_field_name( 'date_filter_adj' ); ?>" type="number" step="1" value="<?php echo (int)( $instance['date_filter_adj'] ); ?>" />
+        <small><?php _e( 'Adjustment in days. Negative values allowed. Only used if Date Filter set to future or past dates.', 'rpwe' );?></small>
+	</p>
+
+
+
 	<div class="rpwe-multiple-check-form">
 		<label>
 			<?php _e( 'Limit to Category', 'recent-posts-widget-extended' ); ?>

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -259,6 +259,10 @@ function rpwe_get_posts( $args = array() ) {
 		$query['tag__in'] = $args['tag'];
 	}
 
+	if( $args['date_filter'] != 'all' ) {
+		$query['date_query'] = array('column' => 'post_date', $args['date_filter'] => $args['date_filter_adj'] . ' days' );
+	}
+
 	/**
 	 * Taxonomy query.
 	 * Prop Miniloop plugin by Kailey Lampert.


### PR DESCRIPTION
Hi,

I want to have a need to show upcoming posts under my 'event' category.  These have dates in the future ( but are published and not just 'scheduled' via another plugin ).  Also added ability to adjust 'now' so that events that happened within the last few days can still show up if you want them too.

None of these behaviors are on by default and current should not be changed.

I hope you like the change!

-poul