### PR TITLE
Add $args to rpwe_markup filter

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -220,7 +220,7 @@ function rpwe_get_recent_posts( $args = array() ) {
 	do_action( 'rpwe_after_loop' );
 
 	// Return the  posts markup.
-	return wp_kses_post( $args['before'] ) . apply_filters( 'rpwe_markup', $html ) . wp_kses_post( $args['after'] );
+	return wp_kses_post( $args['before'] ) . apply_filters( 'rpwe_markup', $html , $args) . wp_kses_post( $args['after'] );
 
 }
 


### PR DESCRIPTION
No arguments are passed when using the filter therefore cannot output the new markup properly. I added the $args variable on  line 223 within the apply_filters function.